### PR TITLE
Add square logos for Nengo GUI.

### DIFF
--- a/nengo-gui/square-dark.svg
+++ b/nengo-gui/square-dark.svg
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg5324"
+   version="1.1"
+   viewBox="0 0 90.529175 90.945704"
+   height="343.73181"
+   width="342.1575"
+   sodipodi:docname="square-dark.svg"
+   inkscape:version="0.92.2 2405546, 2018-03-11">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="995"
+     id="namedview510"
+     showgrid="false"
+     inkscape:zoom="0.16"
+     inkscape:cx="58.921979"
+     inkscape:cy="141.90478"
+     inkscape:window-x="1920"
+     inkscape:window-y="30"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg5324" />
+  <defs
+     id="defs5318">
+    <clipPath
+       id="p594bf549dd">
+      <rect
+         id="rect409"
+         y="79.199997"
+         x="54"
+         width="334.79999"
+         height="613.79999" />
+    </clipPath>
+    <clipPath
+       id="clipPath6004">
+      <rect
+         id="rect6002"
+         y="79.199997"
+         x="54"
+         width="334.79999"
+         height="613.79999" />
+    </clipPath>
+    <clipPath
+       id="clipPath6008">
+      <rect
+         id="rect6006"
+         y="79.199997"
+         x="54"
+         width="334.79999"
+         height="613.79999" />
+    </clipPath>
+    <clipPath
+       id="clipPath6012">
+      <rect
+         id="rect6010"
+         y="79.199997"
+         x="54"
+         width="334.79999"
+         height="613.79999" />
+    </clipPath>
+  </defs>
+  <metadata
+     id="metadata5321">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <rect
+     style="opacity:1;fill:#ff007e;fill-opacity:1;stroke:#ff007e;stroke-width:31.31781387;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="rect4495"
+     width="58.68219"
+     height="58.682186"
+     x="15.923488"
+     y="16.131762" />
+  <g
+     id="g4503"
+     transform="translate(162.54565,-88.081365)">
+    <path
+       inkscape:connector-curvature="0"
+       id="path4566"
+       d="m -116.03178,149.12133 -0.68472,-0.25787 c -0.004,-0.001 -0.008,-0.003 -0.0119,-0.004 l -0.76017,-0.28371 c -0.003,-0.001 -0.007,-0.003 -0.01,-0.004 l -0.76016,-0.28009 c -0.003,-0.001 -0.007,-0.003 -0.0104,-0.004 l -0.76016,-0.27646 c -0.003,-0.001 -0.005,-0.003 -0.008,-0.004 l -0.76016,-0.2744 c -0.003,-0.001 -0.007,-0.003 -0.0104,-0.004 l -0.76015,-0.27233 c -0.003,-8e-4 -0.005,-0.001 -0.008,-0.002 l -0.76016,-0.27026 c -0.003,-0.001 -0.005,-0.003 -0.008,-0.004 l -0.76016,-0.26665 c -0.002,-10e-4 -0.004,-0.003 -0.006,-0.004 l -0.76016,-0.26458 c -0.003,-8e-4 -0.005,-0.001 -0.008,-0.002 l -0.76015,-0.26458 c -0.002,-8e-4 -0.004,-0.001 -0.006,-0.002 l -0.76016,-0.26252 c -0.003,-7.9e-4 -0.005,-0.001 -0.008,-0.002 l -0.76016,-0.25839 c -0.002,-7.9e-4 -0.004,-0.001 -0.006,-0.002 l -0.76016,-0.25839 c -0.002,-7.9e-4 -0.004,-0.001 -0.006,-0.002 l -0.76016,-0.25684 -0.004,-0.002 -0.76016,-0.25477 c -0.002,-7.9e-4 -0.004,-0.001 -0.006,-0.002 l -0.76067,-0.2527 c -0.002,-8e-4 -0.004,-0.001 -0.006,-0.002 l -0.76016,-0.25063 -0.004,-0.002 -0.76016,-0.24856 c -0.002,-7.9e-4 -0.004,-0.001 -0.006,-0.002 l -0.76016,-0.24908 -0.004,-0.002 -0.76016,-0.24702 -0.004,-0.002 -0.76016,-0.24495 c -0.002,-7.9e-4 -0.004,-0.001 -0.006,-0.002 l -0.76016,-0.24494 -0.004,-0.002 -0.76016,-0.24288 -0.004,-0.002 -0.76016,-0.24081 -0.004,-0.002 -0.13125,-0.0413 v 6.50968 l 0.52658,0.17053 0.75396,0.24288 0.75654,0.2465 0.75448,0.24701 0.75602,0.24908 0.75448,0.24856 0.75447,0.25063 0.75396,0.25322 0.75448,0.25425 0.75448,0.25683 0.75447,0.25683 0.75189,0.25838 0.75448,0.26252 0.75241,0.26251 0.75241,0.26459 0.75241,0.26872 0.75034,0.2682 0.75241,0.27233 0.75034,0.2744 0.75034,0.27647 0.74879,0.28009 0.75034,0.28215 0.74621,0.28577 0.74879,0.28836 0.74621,0.29197 0.74466,0.29765 0.74466,0.29973 0.74259,0.3054 0.74052,0.30955 0.73846,0.31574 0.7369,0.32143 0.73277,0.32711 0.73071,0.33486 0.72709,0.34313 0.72088,0.35244 0.7152,0.36277 0.709,0.37207 0.69764,0.38809 0.68367,0.40152 0.6625,0.4191 0.63458,0.4408 0.58601,0.45682 0.49971,0.46405 0.0765,0.0925 1.98489,4.34961 -2.04174,-5.80947 -0.38034,-0.6935 -0.60151,-0.85265 -0.64647,-0.79531 -0.6718,-0.75447 -0.69194,-0.71882 -0.70539,-0.69143 -0.71313,-0.67025 -0.71882,-0.65267 -0.72502,-0.63458 -0.72916,-0.62116 -0.73432,-0.60926 -0.73483,-0.5979 -0.73898,-0.58962 -0.73846,-0.57775 -0.74259,-0.57206 -0.74259,-0.5643 -0.74465,-0.55863 -0.74414,-0.55035 z"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:0.32941176;fill-rule:nonzero;stroke:none;stroke-width:6.19988155;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:100;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4571"
+       d="m -119.00731,139.463 -0.108,-0.0729 c -0.003,-0.002 -0.005,-0.004 -0.008,-0.006 l -0.76016,-0.51108 c -0.003,-0.002 -0.007,-0.004 -0.0103,-0.006 l -0.76016,-0.50746 c -0.003,-0.002 -0.005,-0.004 -0.008,-0.006 l -0.76016,-0.50126 c -0.003,-0.002 -0.007,-0.004 -0.0103,-0.006 l -0.76016,-0.49971 c -0.003,-0.002 -0.005,-0.004 -0.008,-0.006 l -0.76015,-0.49557 c -0.003,-0.001 -0.005,-0.003 -0.008,-0.004 l -0.76016,-0.49403 c -0.003,-0.001 -0.005,-0.003 -0.008,-0.004 l -0.7581,-0.48989 c -0.003,-0.002 -0.005,-0.004 -0.008,-0.006 l -0.76016,-0.48575 c -0.003,-10e-4 -0.005,-0.003 -0.008,-0.004 l -0.76016,-0.48369 c -0.003,-0.001 -0.005,-0.003 -0.008,-0.004 l -0.75861,-0.48214 c -0.003,-0.001 -0.005,-0.003 -0.008,-0.004 l -0.76016,-0.47801 c -0.003,-0.001 -0.005,-0.003 -0.008,-0.004 l -0.75809,-0.47439 c -0.003,-0.001 -0.005,-0.003 -0.008,-0.004 l -0.76016,-0.47181 c -0.002,-0.001 -0.004,-0.003 -0.006,-0.004 l -0.76016,-0.47026 c -0.002,-0.001 -0.004,-0.003 -0.006,-0.004 l -0.76016,-0.46611 c -0.003,-10e-4 -0.005,-0.003 -0.008,-0.004 l -0.76016,-0.46457 c -0.002,-10e-4 -0.004,-0.003 -0.006,-0.004 l -0.75654,-0.45889 c -0.002,-0.001 -0.004,-0.003 -0.006,-0.004 l -0.76016,-0.45837 c -0.002,-0.001 -0.004,-0.003 -0.006,-0.004 l -0.76016,-0.45837 c -0.002,-7.9e-4 -0.004,-0.001 -0.006,-0.002 l -0.76016,-0.45475 c -0.002,-0.001 -0.004,-0.003 -0.006,-0.004 l -0.0227,-0.0135 v 7.23988 l 0.61857,0.37723 0.75447,0.4625 0.75241,0.46613 0.75396,0.46818 0.75241,0.47026 0.75447,0.47232 0.75241,0.47594 0.75241,0.48008 0.75241,0.48007 0.75241,0.48576 0.75241,0.48783 0.75241,0.48989 0.75189,0.49403 0.75086,0.49764 0.7524,0.50126 0.75035,0.50384 0.75034,0.50747 0.75034,0.51108 0.75034,0.51728 0.74828,0.51935 0.74879,0.52503 0.74827,0.52917 0.74828,0.53485 0.74672,0.53898 0.74673,0.54467 0.74414,0.55036 0.74466,0.55862 0.74259,0.5643 0.74259,0.57206 0.73845,0.57775 0.73898,0.58962 0.73483,0.5979 0.73433,0.60927 0.72915,0.62115 0.72502,0.63458 0.71882,0.65268 0.71313,0.67024 0.70539,0.69143 0.69194,0.71882 0.6718,0.75448 0.64647,0.7953 0.60151,0.85266 0.38034,0.6935 2.03709,5.79706 -2.06499,-6.93085 -0.5271,-1.25625 -0.66249,-1.26556 -0.68937,-1.16788 -0.70745,-1.09916 -0.7152,-1.05007 -0.72502,-1.01079 -0.72864,-0.98185 -0.73277,-0.95601 -0.7369,-0.93483 -0.73846,-0.91467 -0.74052,-0.89969 -0.7426,-0.88315 -0.74259,-0.8723 -0.74672,-0.85628 -0.74466,-0.84646 -0.74621,-0.83612 -0.74672,-0.82683 -0.74827,-0.81545 -0.74828,-0.80925 -0.74879,-0.79943 -0.74828,-0.79117 z"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:0.49803922;fill-rule:nonzero;stroke:none;stroke-width:6.19988155;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:100;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4533"
+       d="m -134.4906,124.61895 0.17931,0.15865 0.75241,0.67024 0.75034,0.67593 0.75241,0.67954 0.75241,0.6842 0.75241,0.68936 0.75189,0.6935 0.75086,0.6997 0.75241,0.70538 0.75189,0.709 0.75086,0.7152 0.75241,0.71934 0.75034,0.72657 0.75034,0.73122 0.75241,0.73846 0.75035,0.74259 0.75034,0.75034 0.75034,0.75447 0.75034,0.76378 0.75034,0.76843 0.74879,0.77566 0.75034,0.78394 0.74828,0.79116 0.74879,0.79944 0.74828,0.80925 0.74827,0.81545 0.74672,0.82683 0.74621,0.83612 0.74466,0.84646 0.74672,0.85628 0.74259,0.8723 0.7426,0.88315 0.74052,0.89968 0.73846,0.91468 0.7369,0.93482 0.73277,0.95602 0.72864,0.98185 0.72502,1.01079 0.7152,1.05007 0.70745,1.09916 0.68937,1.16788 0.66249,1.26556 0.5271,1.25625 2.06912,6.94376 -2.08669,-8.15092 -0.62115,-1.90634 -0.70332,-1.78698 -0.7214,-1.64382 -0.72864,-1.54978 -0.73484,-1.48518 -0.73845,-1.43195 -0.74259,-1.38958 -0.74259,-1.35547 -0.74466,-1.32447 -0.74673,-1.29915 -0.7462,-1.27382 -0.74828,-1.25367 -0.74879,-1.23042 -0.74828,-1.21491 -0.75034,-1.19527 -0.74879,-1.17926 -0.75034,-1.16375 -0.74828,-1.14826 -0.75034,-1.13429 -0.75034,-1.12086 -0.0145,-0.0227 -0.54674,-0.54519 c -0.003,-0.003 -0.005,-0.007 -0.008,-0.01 l -0.76016,-0.75241 -0.01,-0.0104 -0.76016,-0.74621 c -0.003,-0.003 -0.007,-0.005 -0.0103,-0.008 l -0.7581,-0.74052 -0.01,-0.01 -0.76015,-0.73277 c -0.003,-0.003 -0.005,-0.007 -0.008,-0.0104 l -0.76016,-0.72864 c -0.003,-0.003 -0.007,-0.005 -0.01,-0.008 l -0.76016,-0.72295 -0.008,-0.008 -0.76016,-0.71726 -0.008,-0.008 -0.76016,-0.71314 -0.008,-0.008 -0.76016,-0.70745 c -0.003,-0.003 -0.007,-0.005 -0.0103,-0.008 l -0.7581,-0.70125 c -0.003,-0.003 -0.007,-0.005 -0.0103,-0.008 l -0.76016,-0.69556 -0.008,-0.008 -0.76016,-0.69143 -0.008,-0.008 -0.76016,-0.68781 c -0.003,-0.002 -0.005,-0.004 -0.008,-0.006 l -0.76016,-0.68213 -0.009,-0.008 -0.76016,-0.678 c -0.003,-0.002 -0.005,-0.004 -0.008,-0.006 l -0.76016,-0.67386 -0.008,-0.008 -0.75861,-0.66766 c -0.003,-0.002 -0.005,-0.004 -0.008,-0.006 l -0.76016,-0.66405 c -0.003,-0.002 -0.005,-0.004 -0.008,-0.006 l -0.76016,-0.66042 -0.008,-0.008 -0.76017,-0.65474 c -0.003,-0.002 -0.005,-0.004 -0.008,-0.006 l -0.44804,-0.38447 z"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:0.65882353;fill-rule:nonzero;stroke:none;stroke-width:6.19988155;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:100;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4546"
+       d="m -149.57237,100.33826 c -0.80188,0 -1.20251,0.37034 -1.20251,1.11053 v 4.71857 c 0,0.74019 0.40063,1.11001 1.20251,1.11001 h 7.03213 v 52.5539 h -7.03213 c -0.80188,0 -1.20251,0.37034 -1.20251,1.11053 v 4.71857 c 0,0.74019 0.40063,1.11001 1.20251,1.11001 h 22.20588 c 0.80188,0 1.20303,-0.36982 1.20303,-1.11001 v -4.71857 c 0,-0.74019 -0.40115,-1.11053 -1.20303,-1.11053 h -7.12411 v -45.52177 -4.48758 l 0.61856,0.73639 0.75035,0.90537 0.75034,0.91312 0.75241,0.92088 0.75034,0.92862 0.75241,0.93845 0.75034,0.94826 0.75086,0.95601 0.75189,0.96583 0.75086,0.97617 0.75034,0.9834 0.75241,0.99529 0.75034,1.00511 0.75034,1.01492 0.75241,1.02475 0.75034,1.03663 0.75035,1.048 0.75034,1.05781 0.75034,1.07022 0.75241,1.08314 0.75034,1.09347 0.75086,1.10898 0.75034,1.12086 0.75034,1.1343 0.74828,1.14825 0.75034,1.16375 0.74879,1.17926 0.75034,1.19527 0.74828,1.21492 0.74879,1.23041 0.74827,1.25367 0.74621,1.27383 0.74672,1.29914 0.74466,1.32447 0.74259,1.35547 0.74259,1.38958 0.73846,1.43196 0.73484,1.48518 0.72864,1.54977 0.7214,1.64383 0.70331,1.78697 0.62115,1.90634 2.0867,8.15093 h 1.22886 1.850537 4.996077 c 0.801878,0 1.203029,-0.37034 1.203029,-1.11053 v -58.38248 h 7.124112 c 0.740193,0 1.110525,-0.37034 1.110525,-1.11053 v -4.71857 c 0,-0.74019 -0.370332,-1.11053 -1.110525,-1.11053 h -22.297865 c -0.74019,0 -1.11053,0.37034 -1.11053,1.11053 v 4.71857 c 0,0.74019 0.37034,1.11053 1.11053,1.11053 h 7.12411 v 42.83614 l -0.49247,-1.04748 c -0.009,-0.0191 -0.0181,-0.0379 -0.0274,-0.0568 l -0.76016,-1.53428 c -0.008,-0.015 -0.0153,-0.03 -0.0233,-0.045 l -0.76016,-1.47537 c -0.006,-0.0124 -0.013,-0.0249 -0.0196,-0.0372 l -0.76016,-1.42421 c -0.006,-0.0111 -0.0122,-0.0226 -0.0181,-0.0336 l -0.76016,-1.38493 c -0.005,-0.01 -0.0103,-0.0198 -0.0155,-0.0295 l -0.76016,-1.35185 c -0.005,-0.008 -0.009,-0.0173 -0.0139,-0.0259 l -0.76016,-1.3224 c -0.005,-0.007 -0.009,-0.0145 -0.0134,-0.0217 l -0.76015,-1.29708 c -0.004,-0.007 -0.008,-0.014 -0.0119,-0.0212 l -0.76016,-1.27382 c -0.004,-0.007 -0.008,-0.013 -0.0119,-0.0196 l -0.76016,-1.25161 c -0.004,-0.006 -0.008,-0.0122 -0.0119,-0.0181 l -0.76017,-1.23248 c -0.004,-0.006 -0.008,-0.0116 -0.0119,-0.0176 l -0.76017,-1.21284 c -0.003,-0.006 -0.007,-0.0116 -0.01,-0.0176 l -0.76016,-1.19527 c -0.003,-0.006 -0.007,-0.0117 -0.0104,-0.0176 l -0.76016,-1.17926 c -0.003,-0.005 -0.007,-0.0107 -0.01,-0.016 l -0.76016,-1.16376 c -0.003,-0.005 -0.007,-0.0102 -0.0103,-0.0155 l -0.76016,-1.15032 c -0.003,-0.005 -0.007,-0.009 -0.01,-0.0134 l -0.76016,-1.13637 c -0.003,-0.005 -0.007,-0.009 -0.0103,-0.0139 l -0.76016,-1.12086 c -0.003,-0.005 -0.007,-0.009 -0.01,-0.0134 l -0.76016,-1.10898 c -0.003,-0.005 -0.007,-0.009 -0.0104,-0.0139 l -0.76016,-1.09709 c -0.003,-0.004 -0.007,-0.008 -0.01,-0.0119 l -0.7581,-1.0852 c -0.003,-0.004 -0.007,-0.008 -0.0103,-0.0119 l -0.76016,-1.07177 c -0.003,-0.005 -0.007,-0.009 -0.01,-0.0134 l -0.76016,-1.05989 c -0.003,-0.004 -0.005,-0.008 -0.008,-0.0119 l -0.76016,-1.05007 c -0.003,-0.004 -0.007,-0.008 -0.01,-0.0119 l -0.76016,-1.03819 c -0.003,-0.004 -0.007,-0.008 -0.0103,-0.0119 l -0.76016,-1.02888 c -0.003,-0.004 -0.005,-0.008 -0.008,-0.0114 l -0.76067,-1.01699 c -0.003,-0.004 -0.007,-0.008 -0.01,-0.0119 l -0.76016,-1.00666 c -0.003,-0.004 -0.005,-0.008 -0.008,-0.0119 l -0.76016,-0.99529 c -0.003,-0.004 -0.007,-0.008 -0.01,-0.0119 l -0.76016,-0.98754 c -0.003,-0.004 -0.005,-0.008 -0.008,-0.0114 l -0.76015,-0.97772 c -0.003,-0.004 -0.007,-0.008 -0.01,-0.0119 l -0.76016,-0.9679 c -0.003,-0.003 -0.005,-0.007 -0.008,-0.01 l -0.76016,-0.96015 -0.01,-0.01 -0.76016,-0.95033 c -0.003,-0.004 -0.005,-0.008 -0.008,-0.0119 l -0.76016,-0.94051 -0.01,-0.01 -0.76016,-0.93276 c -0.003,-0.004 -0.005,-0.008 -0.008,-0.0119 l -0.76016,-0.92294 -0.01,-0.01 -0.76016,-0.91519 c -0.003,-0.004 -0.005,-0.008 -0.008,-0.0114 l -0.76016,-0.90743 -0.01,-0.01 -0.75861,-0.89917 -0.01,-0.0103 -0.76016,-0.88935 c -0.003,-0.004 -0.005,-0.008 -0.008,-0.0119 l -0.76016,-0.8816 -0.01,-0.01 -0.76016,-0.87592 c -0.003,-0.003 -0.005,-0.007 -0.008,-0.0103 l -0.7602,-0.86765 -0.01,-0.0103 c -0.25104,-0.28607 -0.50294,-0.57246 -0.75292,-0.85886 z"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6.19988155;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:100;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+  </g>
+</svg>

--- a/nengo-gui/square-light.svg
+++ b/nengo-gui/square-light.svg
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg5324"
+   version="1.1"
+   viewBox="0 0 67.693335 67.69333"
+   height="191.88661pt"
+   width="191.88661pt"
+   sodipodi:docname="square-light.svg"
+   inkscape:version="0.92.2 2405546, 2018-03-11">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="995"
+     id="namedview226"
+     showgrid="false"
+     inkscape:zoom="0.39"
+     inkscape:cx="173.62935"
+     inkscape:cy="128.43815"
+     inkscape:window-x="1920"
+     inkscape:window-y="30"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg5324" />
+  <defs
+     id="defs5318">
+    <clipPath
+       id="p594bf549dd">
+      <rect
+         id="rect409"
+         y="79.199997"
+         x="54"
+         width="334.79999"
+         height="613.79999" />
+    </clipPath>
+    <clipPath
+       id="clipPath6004">
+      <rect
+         id="rect6002"
+         y="79.199997"
+         x="54"
+         width="334.79999"
+         height="613.79999" />
+    </clipPath>
+    <clipPath
+       id="clipPath6008">
+      <rect
+         id="rect6006"
+         y="79.199997"
+         x="54"
+         width="334.79999"
+         height="613.79999" />
+    </clipPath>
+    <clipPath
+       id="clipPath6012">
+      <rect
+         id="rect6010"
+         y="79.199997"
+         x="54"
+         width="334.79999"
+         height="613.79999" />
+    </clipPath>
+  </defs>
+  <metadata
+     id="metadata5321">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     inkscape:connector-curvature="0"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.6;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#ff007e;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6.19988155;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:100;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="m 35.096047,49.41352 -0.684712,-0.25786 c -0.004,-10e-4 -0.0081,-0.003 -0.01188,-0.004 l -0.760161,-0.2837 c -0.003,-10e-4 -0.0068,-0.003 -0.0098,-0.004 l -0.760161,-0.28009 c -0.003,-10e-4 -0.0073,-0.003 -0.01035,-0.004 L 32.098821,48.3034 c -0.003,-0.001 -0.0048,-0.003 -0.0078,-0.004 L 31.330863,48.025 c -0.003,-10e-4 -0.0073,-0.003 -0.01035,-0.004 l -0.760158,-0.27233 c -0.003,-7.9e-4 -0.0048,-10e-4 -0.0078,-0.002 l -0.760162,-0.27026 c -0.003,-0.001 -0.0053,-0.003 -0.0083,-0.004 l -0.760158,-0.26665 c -0.0021,-10e-4 -0.0042,-0.003 -0.0062,-0.004 l -0.760161,-0.26458 c -0.003,-7.9e-4 -0.0048,-10e-4 -0.0078,-0.002 L 27.489616,46.6706 c -0.0021,-7.9e-4 -0.0042,-10e-4 -0.0062,-0.002 l -0.760162,-0.26251 c -0.003,-8e-4 -0.0053,-10e-4 -0.0083,-0.002 l -0.760159,-0.25838 c -0.002,-8e-4 -0.0037,-10e-4 -0.0057,-0.002 l -0.760161,-0.25838 c -0.002,-8e-4 -0.0042,-0.001 -0.0062,-0.002 l -0.76016,-0.25683 -0.0041,-0.002 -0.760161,-0.25476 c -0.002,-8e-4 -0.0037,-10e-4 -0.0057,-0.002 l -0.760677,-0.2527 c -0.002,-7.9e-4 -0.0037,-10e-4 -0.0057,-0.002 l -0.760161,-0.25063 -0.0041,-0.002 -0.76016,-0.24857 c -0.002,-7.9e-4 -0.0042,-10e-4 -0.0062,-0.002 l -0.760161,-0.24908 -0.0041,-0.002 -0.76016,-0.24702 -0.0036,-0.002 -0.760161,-0.24495 c -0.002,-7.9e-4 -0.0042,-10e-4 -0.0062,-0.002 l -0.760161,-0.24495 -0.0041,-0.002 -0.76016,-0.24288 -0.0041,-0.002 -0.76016,-0.24081 -0.0041,-0.002 -0.131258,-0.0413 v 6.50968 l 0.526583,0.17053 0.753959,0.24288 0.756543,0.2465 0.754476,0.24701 0.756026,0.24908 0.754476,0.24856 0.754476,0.25064 0.753959,0.25321 0.754476,0.25425 0.754476,0.25683 0.754476,0.25683 0.751892,0.25838 0.754476,0.26252 0.752408,0.26252 0.752409,0.26458 0.752408,0.26872 0.750343,0.2682 0.752409,0.27233 0.750342,0.2744 0.750343,0.27647 0.748789,0.28009 0.750342,0.28215 0.746207,0.28577 0.748792,0.28836 0.74621,0.29197 0.744657,0.29765 0.744656,0.29973 0.74259,0.30541 0.740524,0.30954 0.738457,0.31574 0.736905,0.32143 0.732771,0.32711 0.730705,0.33486 0.727088,0.34314 0.720887,0.35243 0.7152,0.36277 0.709002,0.37207 0.697632,0.38809 0.683678,0.40152 0.662493,0.4191 0.634587,0.4408 0.58601,0.45682 0.49971,0.46405 0.07648,0.0925 1.984891,4.34961 -2.041736,-5.80946 -0.380339,-0.6935 -0.601514,-0.85266 -0.646473,-0.7953 -0.671792,-0.75448 -0.691947,-0.71882 -0.705384,-0.69143 -0.713134,-0.67024 -0.71882,-0.65268 -0.725019,-0.63458 -0.729155,-0.62115 -0.734322,-0.60927 -0.734838,-0.5979 -0.738973,-0.58962 -0.738458,-0.57775 -0.74259,-0.57205 -0.74259,-0.56431 -0.744656,-0.55862 -0.744141,-0.55036 z"
+     id="path4566" />
+  <path
+     inkscape:connector-curvature="0"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.74999999;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#ff007e;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6.19988155;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:100;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="m 32.120519,39.7552 -0.108002,-0.0729 c -0.003,-0.002 -0.0048,-0.004 -0.0078,-0.006 l -0.760161,-0.51108 c -0.003,-0.002 -0.0073,-0.004 -0.01035,-0.006 l -0.760161,-0.50746 c -0.003,-0.002 -0.0047,-0.004 -0.0078,-0.006 l -0.760161,-0.50127 c -0.003,-0.002 -0.0073,-0.004 -0.01035,-0.006 l -0.760161,-0.49971 c -0.003,-0.002 -0.0048,-0.004 -0.0078,-0.006 l -0.760159,-0.49557 c -0.003,-0.001 -0.0053,-0.003 -0.0083,-0.004 l -0.760161,-0.49403 c -0.003,-0.001 -0.0053,-0.003 -0.0083,-0.004 l -0.758092,-0.48989 c -0.003,-0.002 -0.0048,-0.004 -0.0078,-0.006 L 25.8648,35.65353 c -0.003,-0.001 -0.0053,-0.003 -0.0083,-0.004 l -0.76016,-0.48369 c -0.003,-0.001 -0.0048,-0.003 -0.0078,-0.004 L 24.32993,34.6797 c -0.003,-10e-4 -0.0048,-0.003 -0.0078,-0.004 l -0.76016,-0.47801 c -0.003,-0.001 -0.0053,-0.003 -0.0083,-0.004 L 22.795576,33.7193 c -0.003,-10e-4 -0.0053,-0.003 -0.0083,-0.004 l -0.76016,-0.4718 c -0.002,-10e-4 -0.0037,-0.003 -0.0057,-0.004 l -0.76016,-0.47026 c -0.002,-0.001 -0.0042,-0.003 -0.0062,-0.004 l -0.76016,-0.46612 c -0.003,-0.001 -0.0053,-0.003 -0.0083,-0.004 l -0.760161,-0.46457 c -0.002,-10e-4 -0.0037,-0.003 -0.0057,-0.004 l -0.756543,-0.45888 c -0.002,-0.001 -0.0042,-0.003 -0.0062,-0.004 l -0.76016,-0.45837 c -0.002,-0.001 -0.0042,-0.003 -0.0062,-0.004 l -0.76016,-0.45837 c -0.002,-7.9e-4 -0.0037,-0.001 -0.0057,-0.002 l -0.76016,-0.45475 c -0.002,-0.001 -0.0042,-0.003 -0.0062,-0.004 l -0.02274,-0.0134 v 7.23987 l 0.618567,0.37723 0.754476,0.46251 0.752409,0.46612 0.753959,0.46819 0.752409,0.47025 0.754476,0.47232 0.752409,0.47595 0.752409,0.48007 0.752408,0.48007 0.752409,0.48576 0.752409,0.48783 0.752409,0.48989 0.751892,0.49403 0.750858,0.49764 0.752409,0.50126 0.750343,0.50385 0.750342,0.50746 0.75034,0.51108 0.750342,0.51728 0.748276,0.51935 0.748792,0.52503 0.748274,0.52917 0.748273,0.53485 0.746726,0.53898 0.746725,0.54467 0.744141,0.55036 0.744656,0.55862 0.742591,0.56431 0.74259,0.57205 0.738457,0.57775 0.738973,0.58963 0.734838,0.59789 0.734322,0.60927 0.729155,0.62115 0.725019,0.63459 0.71882,0.65267 0.713134,0.67024 0.705385,0.69143 0.691946,0.71882 0.671793,0.75448 0.646472,0.7953 0.601514,0.85266 0.380339,0.6935 2.037085,5.79706 -2.064991,-6.93084 -0.527097,-1.25626 -0.662493,-1.26555 -0.689364,-1.16789 -0.707451,-1.09916 -0.7152,-1.05006 -0.725022,-1.01079 -0.728636,-0.98186 -0.732772,-0.95601 -0.736907,-0.93483 -0.738457,-0.91467 -0.740521,-0.89969 -0.742593,-0.88315 -0.74259,-0.8723 -0.746723,-0.85627 -0.744657,-0.84646 -0.746209,-0.83613 -0.746723,-0.82682 -0.748276,-0.81546 -0.748274,-0.80925 -0.748792,-0.79943 -0.748276,-0.79117 z"
+     id="path4571" />
+  <path
+     inkscape:connector-curvature="0"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#ff007e;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6.19988155;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:100;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="m 16.637227,24.91114 0.179317,0.15865 0.752409,0.67024 0.750342,0.67593 0.752409,0.67954 0.752409,0.6842 0.752408,0.68936 0.751893,0.6935 0.750858,0.6997 0.752409,0.70538 0.751892,0.709 0.750859,0.7152 0.752408,0.71934 0.750342,0.72657 0.750342,0.73122 0.752409,0.73846 0.750342,0.74259 0.750342,0.75034 0.75034,0.75448 0.750343,0.76377 0.750342,0.76843 0.748792,0.77567 0.75034,0.78393 0.748276,0.79117 0.748792,0.79943 0.748273,0.80925 0.748276,0.81545 0.746723,0.82683 0.74621,0.83612 0.744657,0.84646 0.746723,0.85628 0.74259,0.8723 0.742593,0.88315 0.740521,0.89969 0.738457,0.91467 0.736907,0.93483 0.732771,0.95601 0.728636,0.98185 0.725022,1.01079 0.715201,1.05007 0.707451,1.09916 0.689364,1.16788 0.662492,1.26556 0.527098,1.25625 2.069126,6.94377 -2.086694,-8.15093 -0.621152,-1.90634 -0.703315,-1.78697 -0.721405,-1.64383 -0.728636,-1.54978 -0.734838,-1.48518 -0.738458,-1.43195 -0.74259,-1.38958 -0.74259,-1.35547 -0.744659,-1.32447 -0.746723,-1.29914 -0.746207,-1.27383 -0.748276,-1.25367 -0.748792,-1.23042 -0.748274,-1.21491 -0.750342,-1.19527 -0.748792,-1.17926 -0.75034,-1.16375 -0.748276,-1.14825 -0.750342,-1.1343 -0.75034,-1.12086 -0.01447,-0.0227 -0.546737,-0.54519 c -0.003,-0.003 -0.0053,-0.007 -0.0083,-0.01 l -0.760159,-0.75241 -0.0098,-0.0104 -0.760161,-0.7462 c -0.003,-0.003 -0.0073,-0.005 -0.01035,-0.008 l -0.758095,-0.74052 -0.0098,-0.01 -0.760159,-0.73277 c -0.003,-0.003 -0.0053,-0.007 -0.0083,-0.0104 L 28.6194,27.50823 c -0.003,-0.003 -0.0068,-0.005 -0.0098,-0.008 l -0.760161,-0.72295 -0.0083,-0.008 -0.760158,-0.71727 -0.0083,-0.008 -0.760162,-0.71314 -0.0078,-0.008 -0.76016,-0.70745 c -0.003,-0.003 -0.0073,-0.005 -0.01033,-0.008 l -0.758093,-0.70125 c -0.003,-0.003 -0.0073,-0.005 -0.01033,-0.008 l -0.76016,-0.69556 -0.0078,-0.008 -0.76016,-0.69143 -0.0083,-0.008 -0.76016,-0.68782 c -0.003,-0.002 -0.0047,-0.004 -0.0078,-0.006 l -0.76016,-0.68213 -0.0088,-0.008 -0.760161,-0.678 c -0.003,-0.002 -0.0053,-0.004 -0.0083,-0.006 l -0.76016,-0.67386 -0.0078,-0.008 -0.75861,-0.66766 c -0.003,-0.002 -0.0047,-0.004 -0.0078,-0.006 l -0.76016,-0.66404 c -0.003,-0.002 -0.0053,-0.004 -0.0083,-0.006 l -0.760161,-0.66042 -0.0078,-0.008 -0.76016,-0.65474 c -0.003,-0.002 -0.0053,-0.004 -0.0083,-0.006 l -0.448035,-0.38448 z"
+     id="path4533" />
+  <path
+     inkscape:connector-curvature="0"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#212121;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6.19988155;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:100;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="m 1.55546,0.630452 c -0.80188,0 -1.20251,0.370337 -1.20251,1.110527 v 4.718575 c 0,0.74019 0.40063,1.11001 1.20251,1.11001 H 8.58759 V 60.12346 H 1.55546 c -0.80188,0 -1.20251,0.37034 -1.20251,1.11053 v 4.71857 c 0,0.74019 0.40063,1.11001 1.20251,1.11001 h 22.20588 c 0.801876,0 1.203027,-0.36982 1.203027,-1.11001 v -4.71857 c 0,-0.74019 -0.401151,-1.11053 -1.203027,-1.11053 H 16.637227 V 14.60169 10.114111 l 0.618567,0.736389 0.750342,0.905372 0.750342,0.913118 0.752408,0.92088 0.750342,0.92862 0.752409,0.93845 0.750342,0.94826 0.750859,0.95601 0.751892,0.96584 0.750858,0.97616 0.750342,0.98341 0.752409,0.99528 0.750341,1.00511 0.750342,1.01493 0.752409,1.02474 0.750342,1.03663 0.750343,1.048 0.75034,1.05781 0.750342,1.07022 0.752409,1.08314 0.750342,1.09348 0.750859,1.10897 0.750342,1.12086 0.75034,1.1343 0.748276,1.14825 0.750343,1.16375 0.748789,1.17926 0.750342,1.19528 0.748276,1.21491 0.748792,1.23041 0.748274,1.25367 0.746207,1.27383 0.746725,1.29914 0.744657,1.32447 0.74259,1.35547 0.74259,1.38958 0.738458,1.43196 0.734837,1.48518 0.728639,1.54977 0.721402,1.64383 0.703316,1.78697 0.621152,1.90635 2.086694,8.15092 h 1.228865 1.850533 4.996077 c 0.801878,0 1.203029,-0.37034 1.203029,-1.11053 V 7.57008 h 7.124112 c 0.740193,0 1.110525,-0.370336 1.110525,-1.110526 V 1.740979 c 0,-0.74019 -0.370332,-1.110527 -1.110525,-1.110527 H 43.932202 c -0.740193,0 -1.110528,0.370337 -1.110528,1.110527 v 4.718575 c 0,0.74019 0.370335,1.110526 1.110528,1.110526 h 7.124112 v 42.83615 l -0.492476,-1.04749 c -0.009,-0.0191 -0.01805,-0.0379 -0.02739,-0.0568 l -0.760162,-1.53427 c -0.008,-0.015 -0.01534,-0.0301 -0.02326,-0.045 l -0.760162,-1.47536 c -0.006,-0.0124 -0.01302,-0.0249 -0.01963,-0.0372 l -0.760158,-1.4242 c -0.006,-0.0111 -0.01217,-0.0226 -0.0181,-0.0336 l -0.760161,-1.38493 c -0.005,-0.01 -0.01027,-0.0198 -0.0155,-0.0295 l -0.760162,-1.35185 c -0.005,-0.008 -0.0092,-0.0173 -0.01394,-0.0258 l -0.760161,-1.3224 c -0.005,-0.007 -0.0087,-0.0145 -0.01344,-0.0217 l -0.760153,-1.29707 c -0.004,-0.007 -0.0081,-0.014 -0.01188,-0.0212 l -0.760161,-1.27382 c -0.004,-0.007 -0.0081,-0.013 -0.01188,-0.0196 l -0.760161,-1.25161 c -0.004,-0.006 -0.0081,-0.0122 -0.01188,-0.0181 l -0.760161,-1.23249 c -0.004,-0.006 -0.0081,-0.0116 -0.01188,-0.0176 l -0.760161,-1.21285 c -0.003,-0.006 -0.0068,-0.0116 -0.0098,-0.0176 l -0.760161,-1.19527 c -0.003,-0.006 -0.0073,-0.0117 -0.01035,-0.0176 l -0.760161,-1.17925 c -0.003,-0.005 -0.0068,-0.0107 -0.0098,-0.016 l -0.760161,-1.16376 c -0.003,-0.005 -0.0073,-0.0102 -0.01035,-0.0155 l -0.760161,-1.15032 c -0.003,-0.005 -0.0068,-0.009 -0.0098,-0.0134 l -0.760159,-1.13636 c -0.003,-0.005 -0.0073,-0.009 -0.01035,-0.014 l -0.760161,-1.12086 c -0.003,-0.005 -0.0068,-0.009 -0.0098,-0.0134 L 36.63192,26.10949 c -0.003,-0.005 -0.0073,-0.009 -0.01035,-0.0139 L 35.861409,24.9985 c -0.003,-0.004 -0.0068,-0.008 -0.0098,-0.0119 l -0.758093,-1.08521 c -0.003,-0.004 -0.0073,-0.008 -0.01035,-0.0119 l -0.760161,-1.07177 c -0.003,-0.005 -0.0068,-0.009 -0.0098,-0.0134 l -0.760161,-1.05988 c -0.003,-0.004 -0.0053,-0.008 -0.0083,-0.0119 l -0.760159,-1.05006 c -0.003,-0.004 -0.0068,-0.008 -0.0098,-0.0119 l -0.760158,-1.03819 c -0.003,-0.004 -0.0073,-0.008 -0.01034,-0.0119 l -0.760161,-1.02888 c -0.003,-0.004 -0.0048,-0.008 -0.0078,-0.0114 l -0.760677,-1.01699 c -0.003,-0.004 -0.0068,-0.008 -0.0098,-0.0119 l -0.760158,-1.00665 c -0.003,-0.004 -0.0053,-0.008 -0.0083,-0.0119 L 28.93723,15.53748 c -0.003,-0.004 -0.0068,-0.008 -0.0098,-0.0119 l -0.760162,-0.98754 c -0.003,-0.004 -0.0053,-0.008 -0.0083,-0.0114 L 27.39881,13.54892 c -0.003,-0.004 -0.0068,-0.008 -0.0098,-0.0119 l -0.760161,-0.9679 c -0.003,-0.003 -0.0053,-0.007 -0.0083,-0.01 l -0.76016,-0.960147 -0.0098,-0.0098 -0.76016,-0.95033 c -0.003,-0.004 -0.0053,-0.0081 -0.0083,-0.01189 l -0.76016,-0.940511 -0.0098,-0.0098 -0.76016,-0.932759 c -0.003,-0.004 -0.0053,-0.0081 -0.0083,-0.01189 l -0.760161,-0.922941 -0.0098,-0.0098 -0.760161,-0.91519 c -0.003,-0.004 -0.0053,-0.0076 -0.0083,-0.01137 l -0.76016,-0.907438 -0.0098,-0.0098 -0.75861,-0.89917 -0.0098,-0.01033 -0.76016,-0.889352 c -0.003,-0.004 -0.0053,-0.0081 -0.0083,-0.01189 l -0.760161,-0.8816 -0.0098,-0.0098 -0.760161,-0.875915 c -0.003,-0.003 -0.0053,-0.0073 -0.0083,-0.01034 l -0.760196,-0.867649 -0.0098,-0.01033 C 17.138996,1.203005 16.887094,0.916614 16.637113,0.630215 Z"
+     id="path4546" />
+</svg>


### PR DESCRIPTION
We should replace the Nengo GUI favicon with the actual Nengo logo. This PR adds square icons for Nengo GUI. I chose pink (#ff007e) as color, but I'm open to other suggestions.

![light](https://user-images.githubusercontent.com/850157/39388468-2f3ee516-4a4e-11e8-8be5-b955039bf25d.png)

![dark](https://user-images.githubusercontent.com/850157/39388471-32c31c48-4a4e-11e8-92aa-b9baa351cdd8.png)
