### PR TITLE
Switch to nengo-sphinx-theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 _build
+.doctrees

--- a/_static/logo.svg
+++ b/_static/logo.svg
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="34.391518mm"
+   height="12.075336mm"
+   viewBox="0 0 34.391517 12.075337"
+   version="1.1"
+   id="svg8"
+   sodipodi:docname="logo3.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.8"
+     inkscape:cx="128.94913"
+     inkscape:cy="24.358762"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     fit-margin-top="1"
+     fit-margin-left="1"
+     fit-margin-right="1"
+     fit-margin-bottom="1"
+     inkscape:window-width="1916"
+     inkscape:window-height="1033"
+     inkscape:window-x="1920"
+     inkscape:window-y="22"
+     inkscape:window-maximized="0" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-77.400323,-35.536421)">
+    <path
+       id="path1602"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:6.61458302px;font-family:Sanchez;-inkscape-font-specification:Sanchez;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 83.945987,44.135254 h -0.92075 q -0.243417,0 -0.359833,-0.09525 -0.105834,-0.105833 -0.105834,-0.34925 v -0.592667 h -0.01058 q -0.169333,0.4445 -0.635,0.783167 -0.465667,0.328083 -1.132417,0.328083 -1.058333,0 -1.725083,-0.740833 -0.656167,-0.740833 -0.656167,-1.93675 0,-1.2065 0.656167,-1.93675 0.66675,-0.740833 1.735667,-0.740833 0.656166,0 1.090083,0.306916 0.433917,0.296334 0.624417,0.73025 h 0.01058 q -0.01058,-0.211666 -0.01058,-0.34925 V 37.245504 H 81.91399 q -0.137583,0 -0.137583,-0.127 v -0.455083 q 0,-0.127 0.137583,-0.127 h 1.312333 q 0.127,0 0.127,0.127 v 6.76275 h 0.592667 q 0.127,0 0.127,0.127 v 0.455083 q 0,0.127 -0.127,0.127 z m -4.677833,-2.624667 q 0,0.878417 0.455083,1.418167 0.465667,0.53975 1.17475,0.53975 0.709083,0 1.164167,-0.529167 0.455083,-0.53975 0.455083,-1.42875 0,-0.889 -0.465667,-1.397 -0.465666,-0.518583 -1.153583,-0.518583 -0.687917,0 -1.164167,0.518583 -0.465666,0.518584 -0.465666,1.397 z"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path1604"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:6.61458302px;font-family:Sanchez;-inkscape-font-specification:Sanchez;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 89.393758,41.637587 h -3.81 q 0.04233,0.878417 0.550333,1.354667 0.518583,0.47625 1.164167,0.47625 0.645583,0 1.100666,-0.275167 0.465667,-0.275166 0.624417,-0.53975 0.08467,-0.105833 0.1905,-0.03175 l 0.28575,0.28575 q 0.0635,0.0635 0.0635,0.116417 0,0.04233 -0.05292,0.116417 -0.04233,0.07408 -0.1905,0.232833 -0.148166,0.15875 -0.423333,0.359833 -0.264583,0.201084 -0.6985,0.338667 -0.423333,0.137583 -0.910167,0.137583 -1.11125,0 -1.862666,-0.73025 -0.740834,-0.73025 -0.740834,-1.957916 0,-1.23825 0.740834,-1.947334 0.740833,-0.719666 1.80975,-0.719666 1.0795,0 1.693333,0.6985 0.613833,0.687916 0.613833,1.862666 0,0.04233 0,0.08467 0,0.137583 -0.148166,0.137583 z m -0.73025,-0.645583 q -0.03175,-0.656167 -0.41275,-1.04775 -0.381,-0.391583 -1.016,-0.391583 -0.635,0 -1.090084,0.359833 -0.455083,0.359833 -0.53975,1.0795 z"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path1606"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:6.61458302px;font-family:Sanchez;-inkscape-font-specification:Sanchez;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 92.718082,44.209337 q -0.709083,0 -1.132417,-0.264583 -0.423333,-0.264583 -0.529166,-0.497417 h -0.02117 q 0.02117,0.518584 0.02117,0.550334 0,0.137583 -0.148167,0.137583 h -0.359833 q -0.137584,0 -0.137584,-0.137583 v -1.5875 q 0,-0.137584 0.137584,-0.137584 h 0.41275 q 0.148166,0 0.148166,0.137584 v 0.211666 q 0.105834,0.3175 0.4445,0.582084 0.402167,0.3175 1.005417,0.3175 1.185333,0 1.185333,-0.8255 0,-0.28575 -0.328083,-0.455084 -0.328083,-0.179916 -0.804333,-0.296333 -0.465667,-0.116417 -0.931334,-0.264583 -0.465666,-0.148167 -0.79375,-0.47625 -0.328083,-0.338667 -0.328083,-0.846667 0,-0.687917 0.497417,-1.090083 0.497416,-0.41275 1.27,-0.41275 1.04775,0 1.502833,0.613833 h 0.02117 q -0.02117,-0.381 -0.02117,-0.391583 0,-0.137584 0.137583,-0.137584 h 0.338667 q 0.137583,0 0.137583,0.137584 v 1.471083 q 0,0.137583 -0.137583,0.137583 h -0.41275 q -0.148167,0 -0.148167,-0.137583 v -0.148167 q 0,-0.28575 -0.338666,-0.560916 -0.328084,-0.28575 -0.85725,-0.28575 -0.529167,0 -0.8255,0.22225 -0.296334,0.22225 -0.296334,0.582083 0,0.34925 0.328084,0.550333 0.338666,0.1905 0.814916,0.306917 0.47625,0.105833 0.9525,0.243417 0.47625,0.137583 0.804334,0.455083 0.338666,0.3175 0.338666,0.878417 0,0.560916 -0.486833,0.994833 -0.47625,0.423333 -1.4605,0.423333 z"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path1608"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:6.61458302px;font-family:Sanchez;-inkscape-font-specification:Sanchez;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 97.715895,44.135254 h -2.021417 q -0.137583,0 -0.137583,-0.127 v -0.455083 q 0,-0.127 0.137583,-0.127 h 0.582083 v -3.788834 h -0.582083 q -0.137583,0 -0.137583,-0.127 v -0.455083 q 0,-0.127 0.137583,-0.127 h 1.3335 q 0.127,0 0.127,0.127 v 4.370917 h 0.560917 q 0.137583,0 0.137583,0.127 v 0.455083 q 0,0.127 -0.137583,0.127 z m -0.60325,-6.773333 q 0.179916,0.179916 0.179916,0.423333 0,0.243417 -0.179916,0.41275 -0.169334,0.169333 -0.41275,0.169333 -0.243417,0 -0.423334,-0.169333 -0.169333,-0.169333 -0.169333,-0.41275 0,-0.243417 0.169333,-0.423333 0.179917,-0.179917 0.423334,-0.179917 0.243416,0 0.41275,0.179917 z"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path1610"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:6.61458302px;font-family:Sanchez;-inkscape-font-specification:Sanchez;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 100.9883,46.611754 q -0.52917,0 -0.80434,-0.07408 -0.264581,-0.07408 -0.433914,-0.137584 -0.15875,-0.05292 -0.275167,-0.116416 -0.116417,-0.05292 -0.22225,-0.116417 -0.465667,-0.306917 -0.34925,-0.4445 l 0.275167,-0.391583 q 0.0635,-0.09525 0.179916,-0.01058 0.01058,0 0.0635,0.04233 0.0635,0.05292 0.116417,0.09525 0.0635,0.04233 0.15875,0.09525 0.105833,0.0635 0.232833,0.105833 0.126998,0.05292 0.275168,0.09525 0.34925,0.09525 0.77258,0.09525 0.762,0 1.21709,-0.370417 0.46566,-0.359833 0.46566,-1.143 v -1.2065 q -0.1905,0.4445 -0.635,0.762 -0.43391,0.3175 -1.09008,0.3175 -1.079501,0 -1.735668,-0.751416 -0.645583,-0.751417 -0.645583,-1.947334 0,-1.195916 0.656167,-1.926166 0.66675,-0.73025 1.725084,-0.73025 0.65617,0 1.10067,0.306916 0.45508,0.296334 0.65616,0.73025 h 0.0212 l -0.0106,-0.836083 q 0,-0.127 0.127,-0.127 h 1.24883 q 0.127,0 0.127,0.127 v 0.455083 q 0,0.127 -0.127,0.127 h -0.5715 v 4.699 q 0,1.132417 -0.6985,1.703917 -0.68792,0.5715 -1.82033,0.5715 z m -1.566338,-5.08 q 0,0.867833 0.465667,1.407583 0.465671,0.529167 1.164171,0.529167 0.6985,0 1.15358,-0.529167 0.46567,-0.529166 0.46567,-1.418166 0,-0.889 -0.46567,-1.407584 -0.45508,-0.518583 -1.15358,-0.518583 -0.6985,0 -1.164171,0.529167 -0.465667,0.529166 -0.465667,1.407583 z"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path1612"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:6.61458302px;font-family:Sanchez;-inkscape-font-specification:Sanchez;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 110.65435,44.135254 h -1.00542 q -0.45508,0 -0.45508,-0.4445 v -2.783417 q 0,-0.613833 -0.29633,-0.9525 -0.29634,-0.338666 -0.86784,-0.338666 -0.81491,0 -1.27,0.66675 -0.0529,0.0635 -0.13758,0.232833 v 2.910417 h 0.56092 q 0.13758,0 0.13758,0.127 v 0.455083 q 0,0.127 -0.13758,0.127 h -2.02142 q -0.13758,0 -0.13758,-0.127 v -0.455083 q 0,-0.127 0.13758,-0.127 h 0.58208 v -3.788834 h -0.58208 q -0.13758,0 -0.13758,-0.127 v -0.455083 q 0,-0.127 0.13758,-0.127 h 1.23825 q 0.13758,0 0.13758,0.127 l -0.0212,0.719667 h 0.0317 q 0.55033,-0.92075 1.70391,-0.92075 0.84667,0 1.32292,0.497416 0.47625,0.497417 0.48683,1.344084 v 2.7305 h 0.59267 q 0.13758,0 0.13758,0.127 v 0.455083 q 0,0.127 -0.13758,0.127 z"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -1,8 +1,0 @@
-{# Import the theme's layout. #}
-{% extends "!layout.html" %}
-
-{%- block extrahead %}
-<link rel="stylesheet" type="text/css" href="{{ pathto("_static/custom.css", 1) }}">
-{# Call the parent block #}
-{{ super() }}
-{%- endblock %}

--- a/conf.py
+++ b/conf.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
 
 from datetime import datetime
-
-import guzzle_sphinx_theme
+import os
 
 extensions = [
     "sphinx.ext.autosectionlabel",
@@ -10,40 +9,40 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.mathjax",
     "sphinx.ext.todo",
-    "guzzle_sphinx_theme",
+    "nengo_sphinx_theme",
 ]
 
-source_suffix = ".rst"
-master_doc = "index"
+# -- sphinx
+nitpicky = True
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "README.rst"]
-
+source_suffix = ".rst"
+source_encoding = "utf-8"
+master_doc = "index"
 project = "Nengo design"
-copyright = "2017, Applied Brain Research"
+copyright = "2017-2018, Applied Brain Research"
 author = "Applied Brain Research"
 version = release = datetime.now().strftime("%Y-%m-%d")
-language = None
 
+# -- sphinx.ext.todo
 todo_include_todos = True
 
 intersphinx_mapping = {
     "nengo": ("https://www.nengo.ai/", None)
 }
 
-# HTML theming
-pygments_style = "sphinx"
-templates_path = ["_templates"]
+# -- nengo_sphinx_theme
+html_theme = "nengo_sphinx_theme"
+pygments_style = "friendly"
+templates_path = []
 html_favicon = "general/favicon.ico"
 html_static_path = ["_static"]
-
-html_theme_path = guzzle_sphinx_theme.html_theme_path()
-html_theme = "guzzle_sphinx_theme"
-
-html_theme_options = {
-    "project_nav_name": "Nengo design",
-    "base_url": "https://www.nengo.ai/design",
+html_logo = os.path.join("_static", "logo.svg")
+html_sidebars = {"**": ["sidebar.html"]}
+html_context = {
+    "css_files": [os.path.join("_static", "custom.css")],
 }
 
-# Other builders
+# -- other
 htmlhelp_basename = "Nengo design"
 
 latex_elements = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-sphinx==1.6.7
-guzzle_sphinx_theme
+sphinx>=1.8
+nengo-sphinx-theme
 ghp-import


### PR DESCRIPTION
To be consistent with the other Nengo docs pages.

As part of switching, we need to set a logo so that you can still reach the index page (at least the way the toctree is set up here). I whipped up three quick possibilities, mostly just simple text in the Sanchez font we use for other logos. Other suggestions welcome, though would be good to make a quick-ish decision as I'd like to merge this before the other PRs in the queue.

1. lowercase :laughing: 

![designlogo1](https://user-images.githubusercontent.com/203709/48269895-aab93000-e406-11e8-85be-b2827772f03c.png)

2. lowercase with N to work as a standalone logo :tada: 

![designlogo2](https://user-images.githubusercontent.com/203709/48269907-b6a4f200-e406-11e8-8471-69550d958651.png)

3. Uppercase :heart: 

![designlogo3](https://user-images.githubusercontent.com/203709/48269922-bd336980-e406-11e8-91e0-861b56b8e557.png)

Vote with the associated emoji, or comment with proposed tweaks!